### PR TITLE
Clean duplicate decl

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -3612,6 +3612,11 @@ void update_contract_arguments(tree srcdecl, tree destdecl)
             						    cmk_all));
     }
 
+  /* For deferred contracts, we currently copy the tokens from the redeclaration
+    onto the decl that will be preserved. This is not ideal because the
+    redeclaration may have erroneous contracts.
+    For non deferred contracts we currently do copy and remap, which is doing
+    more than we need.  */
   if (contract_any_deferred_p (src_contracts))
     {
       copy_deferred_contracts(srcdecl, destdecl);

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1030,8 +1030,7 @@ void copy_deferred_contracts (tree srcdecl, tree destdecl)
 	continue;
       attrs = tree_cons (TREE_PURPOSE (c), TREE_VALUE (c), attrs);
     }
-  attrs = chainon (DECL_ATTRIBUTES (destdecl), nreverse (attrs));
-  DECL_ATTRIBUTES (destdecl) = attrs;
+  set_contract_attributes (destdecl, nreverse (attrs));
 }
 
 /* Returns the parameter corresponding to the return value of a guarded
@@ -3486,7 +3485,6 @@ p2900_check_redecl_contract (tree newdecl, tree olddecl)
 	defer_guarded_contract_match (olddecl, olddecl, old_contracts);
 	/* put the defered contracts on the olddecl so we parse it when
 	  we can.  */
-	remove_contract_attributes (olddecl);
 	copy_deferred_contracts(newdecl, olddecl);
     }
   else if (contract_any_deferred_p (old_contracts)
@@ -3555,7 +3553,6 @@ cxx2a_check_redecl_contract (tree newdecl, tree olddecl)
 	  defer_guarded_contract_match (olddecl, olddecl, old_contracts);
 	  /* put the defered contracts on the olddecl so we parse it when
 	     we can.  */
-	  remove_contract_attributes (olddecl);
 	  copy_deferred_contracts(newdecl, olddecl);
 	}
       else if (contract_any_deferred_p (old_contracts)
@@ -3686,8 +3683,6 @@ void update_contract_arguments(tree srcdecl, tree destdecl)
 
   if (contract_any_deferred_p (src_contracts))
     {
-      if (dest_contracts)
-	remove_contract_attributes (destdecl);
       copy_deferred_contracts(srcdecl, destdecl);
     }
   else

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -348,14 +348,13 @@ enum contract_match_kind
 
 extern void remove_contract_attributes		(tree);
 extern void copy_contract_attributes		(tree, tree);
-extern void remap_contracts			(tree, tree, tree, bool);
 extern void maybe_update_postconditions		(tree);
 extern void rebuild_postconditions		(tree);
 extern bool check_postcondition_result		(tree, tree, location_t);
 extern tree get_precondition_function		(tree);
 extern tree get_postcondition_function		(tree);
 extern tree get_contract_wrapper_function	(tree);
-extern void duplicate_contracts			(tree, tree);
+extern void check_redecl_contract		(tree, tree);
 extern void match_deferred_contracts		(tree);
 extern void defer_guarded_contract_match	(tree, tree, tree);
 extern bool diagnose_misapplied_contracts	(tree);
@@ -370,5 +369,6 @@ extern void finish_function_contracts		(tree);
 extern void set_contract_functions		(tree, tree, tree);
 extern tree build_contract_check		(tree);
 extern void emit_assertion			(tree);
+extern void update_contract_arguments		(tree, tree);
 
 #endif /* ! GCC_CP_CONTRACT_H */

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -346,8 +346,6 @@ enum contract_match_kind
   (DECL_DECLARES_FUNCTION_P (NODE) && DECL_LANG_SPECIFIC (NODE) && \
    DECL_CONTRACT_WRAPPER (NODE))
 
-extern void remove_contract_attributes		(tree);
-extern void copy_contract_attributes		(tree, tree);
 extern void maybe_update_postconditions		(tree);
 extern void rebuild_postconditions		(tree);
 extern bool check_postcondition_result		(tree, tree, location_t);
@@ -360,7 +358,6 @@ extern void defer_guarded_contract_match	(tree, tree, tree);
 extern bool diagnose_misapplied_contracts	(tree);
 extern tree finish_contract_attribute		(tree, tree);
 extern tree invalidate_contract			(tree);
-extern tree splice_out_contracts		(tree);
 extern bool all_attributes_are_contracts_p	(tree);
 extern tree copy_and_remap_contracts		(tree, tree, bool, contract_match_kind);
 extern void start_function_contracts		(tree);

--- a/gcc/cp/cp-gimplify.cc
+++ b/gcc/cp/cp-gimplify.cc
@@ -1546,7 +1546,7 @@ cp_fold_function (tree fndecl)
      be copied onto different functions. We do not want to fold contract trees
      at this point in time. They will get folded when they are emitted.
    */
-  tree contracts = extract_contract_attributes (fndecl);
+  tree contracts = remove_contract_attributes (fndecl);
   cp_walk_tree (&DECL_SAVED_TREE (fndecl), cp_fold_r, &data, NULL);
   set_contract_attributes (fndecl, contracts);
 

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -9104,7 +9104,7 @@ extern void check_param_in_redecl 		(tree, tree);
 extern tree view_as_const                       (tree);
 extern tree maybe_contract_wrap_call	        (tree, tree);
 extern bool emit_contract_wrapper_func          (bool);
-extern tree extract_contract_attributes 	(tree);
+extern tree remove_contract_attributes		(tree);
 extern void set_contract_attributes 		(tree, tree);
 extern void maybe_emit_violation_handler_wrappers (void);
 

--- a/gcc/cp/decl.cc
+++ b/gcc/cp/decl.cc
@@ -2469,14 +2469,14 @@ duplicate_decls (tree newdecl, tree olddecl, bool hiding, bool was_hidden)
   /* Copy all the DECL_... slots specified in the new decl except for
      any that we copy here from the old type.  */
 
-  /* Contracs are currently a part of attributes. They should not participate
+  /* Contracts are currently a part of attributes. They should not participate
      in the merge. Strip them out before the merge and re-apply later.  */
   tree newdecl_sc = NULL_TREE;
   tree olddecl_sc = NULL_TREE;
   if (TREE_CODE (olddecl) == FUNCTION_DECL)
-    olddecl_sc = extract_contract_attributes(olddecl);
+    olddecl_sc = remove_contract_attributes(olddecl);
   if (TREE_CODE (newdecl) == FUNCTION_DECL)
-    newdecl_sc = extract_contract_attributes(newdecl);
+    newdecl_sc = remove_contract_attributes(newdecl);
 
   if (merge_attr)
     DECL_ATTRIBUTES (newdecl)
@@ -2505,9 +2505,9 @@ duplicate_decls (tree newdecl, tree olddecl, bool hiding, bool was_hidden)
       tree new_result_sc = NULL_TREE;
 
       if (TREE_CODE (old_result) == FUNCTION_DECL)
-	old_result_sc = extract_contract_attributes(old_result);
+	old_result_sc = remove_contract_attributes(old_result);
       if (TREE_CODE (new_result) == FUNCTION_DECL)
-	new_result_sc = extract_contract_attributes(new_result);
+	new_result_sc = remove_contract_attributes(new_result);
 
       DECL_ATTRIBUTES (old_result)
 	= (*targetm.merge_decl_attributes) (old_result, new_result);
@@ -3216,12 +3216,12 @@ duplicate_decls (tree newdecl, tree olddecl, bool hiding, bool was_hidden)
      Preserve the contracts so they can be applied later.  */
   tree contracts = NULL_TREE;
   if (TREE_CODE (olddecl) == FUNCTION_DECL)
-    contracts = extract_contract_attributes(olddecl);
+    contracts = remove_contract_attributes(olddecl);
 
   /* Remove contracts from newdecl so they don't get applied when we merge
     the attributes.   */
   if (TREE_CODE (newdecl) == FUNCTION_DECL)
-    extract_contract_attributes(newdecl);
+    remove_contract_attributes(newdecl);
 
   if (TREE_CODE (newdecl) == FUNCTION_DECL)
     {

--- a/gcc/testsuite/g++.dg/contracts/contracts-nested-class1.C
+++ b/gcc/testsuite/g++.dg/contracts/contracts-nested-class1.C
@@ -13,7 +13,7 @@ struct Outer {
   friend void Inner::fn(int n) [[ pre: n > 0 && bob > 1 ]]; // { dg-error "not declared" }
 
   friend void gfn(int p) [[ pre: p > 0 ]];
-  friend void gfn(int q) [[ pre: q > 1 ]]; // { dg-error "'q' was not declared" }
+  friend void gfn(int q) [[ pre: q > 1 ]];
 
   // This should be okay.
   friend void gfn2(int q);

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-friend1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-friend1.C
@@ -33,4 +33,4 @@ int main(int, char**) {
 // { dg-output "contract violation in function void fn0.X. at .*.C:7: .*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function static void X::fns0.X. at .*.C:9: .*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function static void X::fns1.X. at .*.C:10: .*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function static void X::fns2.X. at .*.C:11: .*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function static void X::fns2.X. at .*.C:19: .*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
@@ -359,9 +359,9 @@ int main(int, char**)
 // { dg-output {contract violation in function void G3<T, S>::f.T, S. .with T = double; S = double. at .*:125: s > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 general T S(\n|\r\n|\r)} }
-// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = int. at .*:134: t > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = int. at .*:139: t > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = int. at .*:134: s > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = int. at .*:140: s > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 partial int S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = double. at .*:147: t > 2(\n|\r\n|\r)} }
@@ -374,9 +374,9 @@ int main(int, char**)
 // { dg-output {contract violation in function void G3<T, S>::f.T, S. .with T = char; S = char. at .*:125: s > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 general T S(\n|\r\n|\r)} }
-// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = char. at .*:134: t > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = char. at .*:139: t > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = char. at .*:134: s > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = char. at .*:140: s > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 partial int S(\n|\r\n|\r)} }
 // { dg-output {G3 full int C(\n|\r\n|\r)} }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/deferred1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/deferred1.C
@@ -1,0 +1,49 @@
+// This case should be diagnosed, but we do not handl deferred contracts properly at the moment.
+// For now, diagnose that we at least don't accidentally merge the contracts
+// { dg-do run }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -g3" }
+#include <cassert>
+struct contract
+{
+  int checked = 0;
+};
+
+contract a, b;
+
+bool
+checkA ()
+{
+  a.checked++;
+  return true;
+}
+
+bool
+checkB ()
+{
+  b.checked++;
+  return true;
+}
+
+void
+clear_checks ()
+{
+  a.checked = b.checked = 0;
+
+}
+
+struct S
+{
+  friend int f1(S) post (checkB());
+  friend int f1(S) pre (checkA()){ return 1;};
+};
+
+
+int main()
+{
+  S s;
+
+  clear_checks ();
+  f1(s);
+  assert (a.checked > 0);
+  assert (b.checked == 0);
+}


### PR DESCRIPTION
- renaming `XXX_duplicate_contracts` to `XXX_check_redecl_contract` to make it more obvious this is checking contracts in redeclaration (better name suggestions welcome)
- added `copy_deferred_contracts` which does the shallow copy. For deferred contracts, this is ok for now as we only carry token soup for deferred contracts - there are no sub trees to copy. 
- `remap_contracts` removed as it is no longer used
- merged `remove_contract_attributes` and `extract_contract_attributes` into one function
- `splice_out_contracts` removed as not needed

for `duplicate_decl`/`check_redecl_contracts`, the following approach is used 
- whenever `duplicate_decl` merges attributes, we remove contracts before the merge and apply them later appropriately. This will not be needed once contracts are not part of attributes
- when arguments names are modified in `duplicate_decl` due to the redecl being a definition, the contracts are updated in `update_contract_arguments`. 
- before `duplicate_decl` memcopies newdecl over olddecl, we remove the contracts from the olddecl first and apply it later appropriately. 
- in general, any modifications to the contracts due to having a redeclaration happens in duplicated_decl (with the awful exception for in class friends, see below)
- `check_redecl_contracts` is meant to only check that the contracts on a redeclaration match. It is not intended to modify the contracts. It currently does so if the original contracts were not deferred and the new decl has deferred contracts. This can happen if a friend declaration appears out of class (contracts not deferred) and then it is declared in class (contracts deferred). If we want deferred contracts on the redecl to be parsed, we need to keep them around. Because the redecl will be deleted later, we move the deferred contracts onto the olddecl. We also store the old non deferred contracts for later deferred contract match. This process should also eventually be fixed and we should not be modifying the olddecl contracts, we should be storing the deferred parse contracts for later match.